### PR TITLE
Retrying policy, resolves #3

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -14,9 +14,12 @@ const (
 	testSplunkToken = "00000000-0000-0000-0000-000000000000"
 )
 
-var insecureClient *http.Client = &http.Client{Transport: &http.Transport{
-	TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-}}
+var testHttpClient *http.Client = &http.Client{
+	Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	},
+	Timeout: 100 * time.Millisecond,
+}
 
 func TestHEC_WriteEvent(t *testing.T) {
 	event := &Event{
@@ -29,7 +32,7 @@ func TestHEC_WriteEvent(t *testing.T) {
 	}
 
 	c := NewClient(testSplunkURL, testSplunkToken)
-	c.SetHTTPClient(insecureClient)
+	c.SetHTTPClient(testHttpClient)
 	err := c.WriteEvent(event)
 	assert.NoError(t, err)
 }
@@ -48,7 +51,7 @@ func TestHEC_WriteObjectEvent(t *testing.T) {
 	}
 
 	c := NewClient(testSplunkURL, testSplunkToken)
-	c.SetHTTPClient(insecureClient)
+	c.SetHTTPClient(testHttpClient)
 	err := c.WriteEvent(event)
 	assert.NoError(t, err)
 }
@@ -60,7 +63,7 @@ func TestHEC_WriteEventBatch(t *testing.T) {
 	}
 
 	c := NewClient(testSplunkURL, testSplunkToken)
-	c.SetHTTPClient(insecureClient)
+	c.SetHTTPClient(testHttpClient)
 	err := c.WriteBatch(events)
 	assert.NoError(t, err)
 }
@@ -72,7 +75,7 @@ func TestHEC_WriteEventRaw(t *testing.T) {
 		Source: String("test-hec-raw"),
 	}
 	c := NewClient(testSplunkURL, testSplunkToken)
-	c.SetHTTPClient(insecureClient)
+	c.SetHTTPClient(testHttpClient)
 	err := c.WriteRaw([]byte(events), &metadata)
 	assert.NoError(t, err)
 }

--- a/cluster.go
+++ b/cluster.go
@@ -15,6 +15,8 @@ type Cluster struct {
 	clients []*Client
 
 	mtx sync.Mutex
+
+	maxRetries int
 }
 
 func NewCluster(serverURLs []string, token string) HEC {
@@ -27,10 +29,12 @@ func NewCluster(serverURLs []string, token string) HEC {
 			token:      token,
 			keepAlive:  true,
 			channel:    channel,
+			retries:    0, // try only once for each client
 		}
 	}
 	return &Cluster{
-		clients: clients,
+		clients:    clients,
+		maxRetries: -1, // default: try all clients
 	}
 }
 
@@ -58,18 +62,56 @@ func (c *Cluster) SetChannel(channel string) {
 	c.mtx.Unlock()
 }
 
+func (c *Cluster) SetMaxRetry(retries int) {
+	c.maxRetries = retries
+}
+
 func (c *Cluster) WriteEvent(event *Event) error {
-	return pick(c.clients).WriteEvent(event)
+	return c.retry(func(client *Client) error {
+		return client.WriteEvent(event)
+	})
 }
 
 func (c *Cluster) WriteBatch(events []*Event) error {
-	return pick(c.clients).WriteBatch(events)
+	return c.retry(func(client *Client) error {
+		return client.WriteBatch(events)
+	})
 }
 
 func (c *Cluster) WriteRaw(events []byte, metadata *EventMetadata) error {
-	return pick(c.clients).WriteRaw(events, metadata)
+	return c.retry(func(client *Client) error {
+		return client.WriteRaw(events, metadata)
+	})
 }
 
-func pick(clients []*Client) *Client {
-	return clients[rand.Int()%len(clients)]
+func (c *Cluster) retry(writeFunc func(*Client) error) error {
+	exclude := make([]*Client, 0)
+	var err error
+	for t := 0; t < len(c.clients) && t != c.maxRetries; t++ {
+		client := pick(c.clients, exclude)
+		// If failed to write into this client, exclude it and try others
+		if err = writeFunc(client); err != nil {
+			exclude = append(exclude, client)
+		} else {
+			return nil
+		}
+	}
+	return err
+}
+
+func pick(clients []*Client, exclude []*Client) *Client {
+	var choice *Client
+	for choice == nil {
+		choice = clients[rand.Int()%len(clients)]
+		if exclude == nil {
+			break
+		}
+		for _, bad := range exclude {
+			if bad == choice {
+				choice = nil
+				break
+			}
+		}
+	}
+	return choice
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -21,7 +21,7 @@ func TestCluster_WriteEvent(t *testing.T) {
 	}
 
 	c := NewCluster(testSplunkURLs, testSplunkToken)
-	c.SetHTTPClient(insecureClient)
+	c.SetHTTPClient(testHttpClient)
 	err := c.WriteEvent(event)
 	assert.NoError(t, err)
 }
@@ -39,7 +39,7 @@ func TestCluster_WriteEventBatch(t *testing.T) {
 	}
 
 	c := NewCluster(testSplunkURLs, testSplunkToken)
-	c.SetHTTPClient(insecureClient)
+	c.SetHTTPClient(testHttpClient)
 	for _, batch := range eventBatches {
 		err := c.WriteBatch(batch)
 		assert.NoError(t, err)
@@ -57,9 +57,20 @@ func TestCluster_WriteEventRaw(t *testing.T) {
 		Source: String("test-hec-raw"),
 	}
 	c := NewCluster(testSplunkURLs, testSplunkToken)
-	c.SetHTTPClient(insecureClient)
+	c.SetHTTPClient(testHttpClient)
 	for _, block := range eventBlocks {
 		err := c.WriteRaw([]byte(block), &metadata)
+		assert.NoError(t, err)
+	}
+}
+
+func TestCluster_Retrying(t *testing.T) {
+	event := &Event{Event: "test retrying"}
+	partlyBrokenUrls := []string{"http://127.0.0.1:8088", "http://example.com:8088", "http://example.com:88"}
+	c := NewCluster(partlyBrokenUrls, testSplunkToken)
+	c.SetHTTPClient(testHttpClient)
+	for i := 0; i < 5; i++ {
+		err := c.WriteEvent(event)
 		assert.NoError(t, err)
 	}
 }

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,30 @@
+package hec
+
+// Response is response message from HEC. For example, `{"text":"Success","code":0}`.
+type Response struct {
+	Text string `json:"text"`
+	Code int    `json:"code"`
+}
+
+// Response status codes
+const (
+	StatusSuccess              = 0
+	StatusTokenDisabled        = 1
+	StatusTokenRequired        = 2
+	StatusInvalidAuthorization = 3
+	StatusInvalidToken         = 4
+	StatusNoData               = 5
+	StatusInvalidDataFormat    = 6
+	StatusIncorrectIndex       = 7
+	StatusInternalServerError  = 8
+	StatusServerBusy           = 9
+	StatusChannelMissing       = 10
+	StatusInvalidChannel       = 11
+	StatusEventFieldRequired   = 12
+	StatusEventFieldBlank      = 13
+	StatusAckDisabled          = 14
+)
+
+func retriable(code int) bool {
+	return code == StatusServerBusy || code == StatusInternalServerError
+}

--- a/hec.go
+++ b/hec.go
@@ -6,6 +6,7 @@ type HEC interface {
 	SetHTTPClient(client *http.Client)
 	SetKeepAlive(enable bool)
 	SetChannel(channel string)
+	SetMaxRetry(retries int)
 
 	WriteEvent(event *Event) error
 	WriteBatch(events []*Event) error


### PR DESCRIPTION
For stand-alone Splunk, retry for `MaxRetries`.

For Search Head Cluster, retry for `min(MaxRetries, ClusterSize)` on each different endpoint