### PR TITLE
uuid: update dep

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,12 +43,16 @@ type Client struct {
 }
 
 func NewClient(serverURL string, token string) HEC {
+	id, err := uuid.NewV4()
+	if err != nil {
+		panic(err)
+	}
 	return &Client{
 		httpClient: http.DefaultClient,
 		serverURL:  serverURL,
 		token:      token,
 		keepAlive:  true,
-		channel:    uuid.NewV4().String(),
+		channel:    id.String(),
 		retries:    2,
 		maxLength:  defaultMaxContentLength,
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -21,7 +21,11 @@ type Cluster struct {
 }
 
 func NewCluster(serverURLs []string, token string) HEC {
-	channel := uuid.NewV4().String()
+	id, err := uuid.NewV4()
+	if err != nil {
+		panic(err)
+	}
+	channel := id.String()
 	clients := make([]*Client, len(serverURLs))
 	for i, serverURL := range serverURLs {
 		clients[i] = &Client{

--- a/glide.lock
+++ b/glide.lock
@@ -1,18 +1,18 @@
-hash: d67c488865226f4c402d39ff488b78fc1846487549e853446e3fdfbb4e0f1139
-updated: 2017-01-24T15:26:57.736813195+08:00
+hash: 7dc4e8d6aa27ea3668054597c06cd98ccb53411b9f19c795e5385d49e504ee5e
+updated: 2018-01-04T11:49:23.156951+01:00
 imports:
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: 36e9d2ebbde5e3f13ab2e25625fd453271d6522e
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: ecdeabc65495df2dec95d7c4a4c3e021903035e5
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  version: b91bfb9ebec76498946beb6af7c0230c7cc7ba6c
   subpackages:
   - assert

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/fuyufjh/splunk-hec-go
 import:
 - package: github.com/satori/go.uuid
-  version: ^1.1.0
+  version: master
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4


### PR DESCRIPTION
The signature for uuid.NewV4() changed, causing users of NewCluster()
and NewClient() to fail if they're vendoring splunk-hec-go.