### PR TITLE
Use httptest to provide a splunk-free way of running tests

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -42,6 +42,26 @@ func TestHEC_WriteEvent(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestHEC_WriteEventServerFailure(t *testing.T) {
+	event := &Event{
+		Index:      String("main"),
+		Source:     String("test-hec-raw"),
+		SourceType: String("manual"),
+		Host:       String("localhost"),
+		Time:       String("1485237827.123"),
+		Event:      "hello, world",
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"text":"Data channel is missing","code":10}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
+	c.SetHTTPClient(testHttpClient)
+	err := c.WriteEvent(event)
+	assert.Error(t, err)
+}
+
 func TestHEC_WriteObjectEvent(t *testing.T) {
 	event := &Event{
 		Index:      String("main"),

--- a/client_test.go
+++ b/client_test.go
@@ -169,6 +169,23 @@ func TestHEC_WriteLongEventRaw(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestHEC_WriteRawFailure(t *testing.T) {
+	events := `2017-01-24T06:07:10.488Z Raw event one
+2017-01-24T06:07:12.434Z Raw event two`
+	metadata := EventMetadata{
+		Source: String("test-hec-raw"),
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte(`{"text":"Oh no","code":90}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
+	c.SetMaxContentLength(40)
+	c.SetHTTPClient(testHttpClient)
+	err := c.WriteRaw(strings.NewReader(events), &metadata)
+	assert.Error(t, err)
+}
+
 func TestBreakStream(t *testing.T) {
 	text := "This is line A\nThis is line B" // length of every line is 14
 

--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package hec
 import (
 	"crypto/tls"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -32,7 +33,10 @@ func TestHEC_WriteEvent(t *testing.T) {
 		Event:      "hello, world",
 	}
 
-	c := NewClient(testSplunkURL, testSplunkToken)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"text":"Success","code":0}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
 	c.SetHTTPClient(testHttpClient)
 	err := c.WriteEvent(event)
 	assert.NoError(t, err)
@@ -51,7 +55,10 @@ func TestHEC_WriteObjectEvent(t *testing.T) {
 		},
 	}
 
-	c := NewClient(testSplunkURL, testSplunkToken)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"text":"Success","code":0}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
 	c.SetHTTPClient(testHttpClient)
 	err := c.WriteEvent(event)
 	assert.NoError(t, err)
@@ -67,7 +74,11 @@ func TestHEC_WriteLongEvent(t *testing.T) {
 		Event:      "hello, world",
 	}
 
-	c := NewClient(testSplunkURL, testSplunkToken)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"text":"Success","code":0}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
+
 	c.SetHTTPClient(testHttpClient)
 	c.SetMaxContentLength(20) // less than full event
 	err := c.WriteEvent(event)
@@ -81,7 +92,11 @@ func TestHEC_WriteEventBatch(t *testing.T) {
 		{Event: "event two"},
 	}
 
-	c := NewClient(testSplunkURL, testSplunkToken)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"text":"Success","code":0}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
+
 	c.SetHTTPClient(testHttpClient)
 	err := c.WriteBatch(events)
 	assert.NoError(t, err)
@@ -93,7 +108,10 @@ func TestHEC_WriteLongEventBatch(t *testing.T) {
 		{Event: "event two"},
 	}
 
-	c := NewClient(testSplunkURL, testSplunkToken)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"text":"Success","code":0}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
 	c.SetHTTPClient(testHttpClient)
 	c.SetMaxContentLength(25)
 	err := c.WriteBatch(events)
@@ -106,7 +124,10 @@ func TestHEC_WriteEventRaw(t *testing.T) {
 	metadata := EventMetadata{
 		Source: String("test-hec-raw"),
 	}
-	c := NewClient(testSplunkURL, testSplunkToken)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"text":"Success","code":0}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
 	c.SetHTTPClient(testHttpClient)
 	err := c.WriteRaw(strings.NewReader(events), &metadata)
 	assert.NoError(t, err)
@@ -118,7 +139,10 @@ func TestHEC_WriteLongEventRaw(t *testing.T) {
 	metadata := EventMetadata{
 		Source: String("test-hec-raw"),
 	}
-	c := NewClient(testSplunkURL, testSplunkToken)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"text":"Success","code":0}`))
+	}))
+	c := NewClient(ts.URL, testSplunkToken)
 	c.SetMaxContentLength(40)
 	c.SetHTTPClient(testHttpClient)
 	err := c.WriteRaw(strings.NewReader(events), &metadata)

--- a/client_test.go
+++ b/client_test.go
@@ -3,7 +3,6 @@ package hec
 import (
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -59,7 +58,7 @@ func jsonEndpoint(t *testing.T) http.Handler {
 		}
 		if failed {
 			w.WriteHeader(400)
-			w.Write([]byte(fmt.Sprintf(`{"text": %q, "code": 90}`, fmt.Errorf("Failed to decode JSON: %v", err).Error())))
+			w.Write([]byte(`{"text": "Error processing event", "code": 90}`))
 		} else {
 			w.Write([]byte(`{"text":"Success","code":0}`))
 		}


### PR DESCRIPTION
This PR updates the tests to not require running a splunk instance (I don't know how to configure one, but I can read the API docs and provide a fake response!). 

This way, we can run the tests on a stand-alone box/container and even run them on CI systems (: