### PR TITLE
Implement Indexer Acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ go build -o build/example ./example/main.go
 - [x] Send batch of events
 - [x] Customize retrying times
 - [x] Cut big batch into chunk less than MaxContentLength
+- [x] Indexer acknowledgement
 - [ ] Streaming data via HEC Raw
-- [ ] Indexer acknowledgement
 
 ## Example
 

--- a/errors.go
+++ b/errors.go
@@ -6,9 +6,10 @@ import (
 
 // Response is response message from HEC. For example, `{"text":"Success","code":0}`.
 type Response struct {
-	Text  string `json:"text"`
-	Code  int    `json:"code"`
-	AckID string `json:"ackID,omitempty"`
+	Text  string          `json:"text"`
+	Code  int             `json:"code"`
+	AckID *int            `json:"ackId"` // Use a pointer so we can differentiate between a 0 and an ack ID not being specified
+	Acks  map[string]bool `json:"acks"`  // Splunk returns ack IDs as strings rather than ints
 }
 
 // Response status codes

--- a/errors.go
+++ b/errors.go
@@ -6,8 +6,9 @@ import (
 
 // Response is response message from HEC. For example, `{"text":"Success","code":0}`.
 type Response struct {
-	Text string `json:"text"`
-	Code int    `json:"code"`
+	Text  string `json:"text"`
+	Code  int    `json:"code"`
+	AckID string `json:"ackID,omitempty"`
 }
 
 // Response status codes

--- a/hec.go
+++ b/hec.go
@@ -1,6 +1,7 @@
 package hec
 
 import (
+	"context"
 	"io"
 	"net/http"
 )
@@ -20,4 +21,10 @@ type HEC interface {
 
 	// WriteRaw writes raw data stream via HEC raw mode
 	WriteRaw(reader io.ReadSeeker, metadata *EventMetadata) error
+
+	// WaitForAcknowledgement blocks until the Splunk indexer acknowledges data sent to it
+	WaitForAcknowledgement() error
+
+	// WaitForAcknowledgementWithContext blocks until the Splunk indexer acknowledges data sent to it with a context for cancellation
+	WaitForAcknowledgementWithContext(ctx context.Context) error
 }

--- a/util.go
+++ b/util.go
@@ -1,0 +1,11 @@
+package hec
+
+func remove(l []int, item int) []int {
+	for i, other := range l {
+		if other == item {
+			return append(l[:i], l[i+1:]...)
+		}
+	}
+
+	return l
+}


### PR DESCRIPTION
This pull request implements support for the HEC's indexer acknowledgement feature.

It's implemented by adding a `WaitForAcknowledgement` method to `*hec.Client` (and a corresponding `WithContext` variant) that blocks until all previously submitted data has been acknowledged. It will poll the HEC `ack` endpoint until all acknowledgement IDs have been confirmed. It will retry every `retryWaitTime` (currently set to 1 second) until all data is acknowledged or the context is cancelled; if the non-WithContext method is used, an ephemeral context with a timeout of `defaultAcknowledgementTimeout` (I set this to 90 seconds) is used.

It uses a mutex to lock access to the list of acknowledgement IDs and should be threadsafe.